### PR TITLE
Drop maxRedeliveries down to 0.

### DIFF
--- a/alpaca.properties
+++ b/alpaca.properties
@@ -1,5 +1,5 @@
 # Common options
-error.maxRedeliveries=5
+error.maxRedeliveries=0
 jms.brokerUrl=tcp://activemq:61616
 jms.username=
 jms.password=


### PR DESCRIPTION
Given we are dealing only with derivatives, which due to the default `disableStreamCache=true` configuration, and the difficulties in enabling spooling to handle large files if we wanted to move to `disableStreamCache=false`, let's just kill off the attempts to perform redeliveries that can never success for the present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic redelivery of failed messages during error processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/discoverygarden/alpaca-image/pull/16)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->